### PR TITLE
Replaced bulk APIs with new tool mongo2avro

### DIFF
--- a/src/python/WMArchive/Storage/AvroIO.py
+++ b/src/python/WMArchive/Storage/AvroIO.py
@@ -14,9 +14,7 @@ from __future__ import print_function, division
 # system modules
 import io
 import os
-import bz2
 import json
-import gzip
 import itertools
 from types import GeneratorType
 
@@ -28,16 +26,39 @@ from avro.io import DatumReader, DatumWriter
 # WMArchive modules
 from WMArchive.Storage.BaseIO import Storage
 from WMArchive.Utils.Regexp import PAT_UID
-from WMArchive.Utils.Utils import wmaHash
-from WMArchive.Utils.Utils import bulk_avsc, bulk_data
+from WMArchive.Utils.Utils import wmaHash, open_file, file_name
 
-def fileName(uri, wmaid):
-    "Construct common file name"
-    return '%s/%s.avro' % (uri, wmaid)
+class AvroSerializer(object):
+    """
+    AvroSerializer provides two APIs to encode and decode
+    given data into Avro binary format based on given schema.
+    """
+    def __init__(self, schema):
+        self.writer = avro.io.DatumWriter(schema)
+        self.reader = avro.io.DatumReader(schema)
+
+    def encode(self, data):
+        "Encode given data into binary stream"
+        bytes_writer = io.BytesIO()
+        encoder = avro.io.BinaryEncoder(bytes_writer)
+        self.writer.write(data, encoder)
+        return bytes_writer.getvalue()
+
+    def decode(self, data):
+        "Decode given binary data into list of records"
+        out = []
+        decoder = avro.io.BinaryDecoder(io.BytesIO(data))
+        while True:
+            try:
+                rec = self.reader.read(decoder)
+                out.append(rec)
+            except:
+                break
+        return out
 
 class AvroStorage(Storage):
     "Storage based on Avro file based back-end"
-    def __init__(self, uri):
+    def __init__(self, uri, compress=True):
         "ctor with avro uri: avroio:/path/schema.avsc"
         Storage.__init__(self, uri)
         schema = self.uri
@@ -48,49 +69,39 @@ class AvroStorage(Storage):
             os.makedirs(self.hdir)
         schema_doc = open(schema).read()
         self.schema = avro.schema.parse(schema_doc)
-        self.schema_bulk = avro.schema.parse(json.dumps(bulk_avsc(schema_doc)))
+        self.mgr = AvroSerializer(self.schema)
+        self.compress = compress
 
     def file_write(self, fname, data):
         "Write documents in append mode to given file name"
         schema = self.schema
         if  not hasattr(data, '__iter__') or isinstance(data, dict):
             data = [data]
-        with open(fname, 'a') as ostream:
-            with DataFileWriter(ostream, DatumWriter(), schema) as writer:
-                for rec in data:
-                    wmaid = rec.get('wmaid', wmaHash(rec))
-                    writer.append(rec)
-                    writer.flush()
-                    yield wmaid
+        wmaids = []
+        with open_file(fname, 'a') as ostream:
+            for rec in data:
+                data_bytes = self.mgr.encode(rec)
+                ostream.write(data_bytes)
+                ostream.flush()
+                wmaid = rec.get('wmaid', wmaHash(rec))
+                wmaids.append(wmaid)
+        return wmaids
 
     def file_read(self, fname):
         "Read documents from given file name"
         schema = self.schema
-        if  fname.endswith('.gz'):
-            istream = gzip.open(fname)
-        elif fname.endswith('.bz2'):
-            istream = bz2.BZ2File(fname)
-        else:
-            istream = open(fname)
         out = []
-        with istream:
-            reader = DataFileReader(istream, DatumReader())
-            try:
-                for data in reader:
-                    out.append(data)
-            except UnicodeDecodeError:
-                pass
+        with open_file(fname) as istream:
+            data_bytes = istream.read()
+            out = self.mgr.decode(data_bytes)
         return out
 
-    def _write(self, data, bulk=False):
+    def _write(self, data):
         "Internal write API"
         wmaid = self.wmaid(data)
         schema = self.schema
-        if  bulk:
-            schema = self.schema_bulk
-            data = bulk_data(data)
-        fname = fileName(self.hdir, wmaid)
-        with open(fname, 'w') as ostream:
+        fname = file_name(self.hdir, wmaid)
+        with open_file(fname, 'w') as ostream:
             with DataFileWriter(ostream, DatumWriter(), schema) as writer:
                 writer.append(data)
 
@@ -98,8 +109,8 @@ class AvroStorage(Storage):
         "Internal read API"
         if  PAT_UID.match(str(query)): # requested to read concrete file
             out = []
-            fname = fileName(self.hdir, query)
-            with open(fname) as istream:
+            fname = file_name(self.hdir, query)
+            with open_file(fname) as istream:
                 reader = DataFileReader(istream, DatumReader())
                 for data in reader:
                     if  isinstance(data, list):

--- a/src/python/WMArchive/Storage/BaseIO.py
+++ b/src/python/WMArchive/Storage/BaseIO.py
@@ -46,19 +46,10 @@ class Storage(object):
         "Internal write API, should be implemented in subclasses"
         pass
 
-    def write_bulk(self, data):
-        "Bulk write API, return ids of stored documents"
-        if  not (isinstance(data, list) or isinstance(data, GeneratorType)):
-            return self.write(data)
-        wmaid = self.wmaid(data) # generate one id for all data bulk
-        self._write(data, bulk=True)
-        return [wmaid] # must return list to be consistent with write API
-
     def write(self, data, safe=False):
         """
         Write API, return ids of stored documents. All documents are writen
-        via self._write API one by one. For bulk write user should use write_bulk
-        API.
+        via self._write API one by one.
         """
         wmaids = self.getids(data)
         if  isinstance(data, list) or isinstance(data, GeneratorType):

--- a/src/python/WMArchive/Storage/FileIO.py
+++ b/src/python/WMArchive/Storage/FileIO.py
@@ -13,14 +13,13 @@ from __future__ import print_function, division
 # system modules
 import os
 import json
-import gzip
 import itertools
 from types import GeneratorType
 
 # WMArchive modules
 from WMArchive.Storage.BaseIO import Storage
 from WMArchive.Utils.Regexp import PAT_UID
-from WMArchive.Utils.Utils import wmaHash
+from WMArchive.Utils.Utils import wmaHash, open_file
 
 class FileStorage(Storage):
     "Storage based on FileDB back-end"
@@ -30,18 +29,18 @@ class FileStorage(Storage):
         if  not os.path.exists(self.uri):
             os.makedirs(self.uri)
 
-    def _write(self, data, bulk=False):
+    def _write(self, data):
         "Internal write API"
         wmaid = self.wmaid(data)
         fname = '%s/%s.gz' % (self.uri, wmaid)
-        with gzip.open(fname, 'w') as ostream:
+        with open_file(fname, 'w') as ostream:
             ostream.write(json.dumps(data))
 
     def _read(self, query=None):
         "Internal read API"
         if  PAT_UID.match(str(query)): # requested to read concrete file
             fname = '%s/%s.gz' % (self.uri, query)
-            data = json.load(gzip.open(fname))
+            data = json.load(open_file(fname))
             if  isinstance(data, list):
                 for rec in data:
                     self.check(rec)

--- a/src/python/WMArchive/Storage/MongoIO.py
+++ b/src/python/WMArchive/Storage/MongoIO.py
@@ -56,10 +56,6 @@ class MongoStorage(Storage):
         print(tstamp('WMA INFO'), self.coll)
         self.chunk_size = chunk_size
 
-    def write_bulk(self, data):
-        "Bulk write API, return ids of stored documents"
-        return self.write(data)
-
     def write(self, data):
         "Write API, return ids of stored documents"
         if  not isinstance(data, list):
@@ -82,13 +78,16 @@ class MongoStorage(Storage):
         return wmaids
 
     def read(self, query=None):
-        "Read API"
+        "Read API, it reads data from MongoDB storage for provided query."
         gen = self.find(query)
         docs = [r for r in gen]
         return docs
 
     def find(self, query=None):
-        "Read API"
+        """
+        Find records in MongoDB storage for provided query, returns generator
+        over MongoDB collection
+        """
         if  not query:
             query = {}
         if  isinstance(query, list):

--- a/test/python/WMArchive_t/AvroIO_t.py
+++ b/test/python/WMArchive_t/AvroIO_t.py
@@ -14,6 +14,7 @@ import os
 import json
 import tempfile
 import unittest
+from tempfile import mkdtemp
 
 # avro modules
 import avro.schema
@@ -22,7 +23,7 @@ from avro.io import DatumReader, DatumWriter
 
 # WMArchive modules
 from WMArchive.Tools.json2avsc import genSchema
-from WMArchive.Storage.AvroIO import AvroStorage
+from WMArchive.Storage.AvroIO import AvroStorage, AvroSerializer
 from WMArchive.Utils.Utils import wmaHash
 
 class FileStorageTest(unittest.TestCase):
@@ -54,14 +55,14 @@ class FileStorageTest(unittest.TestCase):
         data = self.mgr.read(wmaids[0])
         self.assertEqual(data[0], self.bare_data)
 
-    def test_write_bulk(self):
-        "Test write functionality"
-        bdata = [self.data, self.data]
-        bare_data = [self.bare_data, self.bare_data]
-        wmaids = self.mgr.write_bulk(bdata)
-        self.assertEqual(len(wmaids), 1)
-        data = self.mgr.read(wmaids[0])
-        self.assertEqual(data, bare_data)
+    def test_file_write(self):
+        "Test file_write functionality"
+        for ext in ['', '.bz2', '.gz']:
+            fname = os.path.join(self.tdir, 'file.avro'+ext)
+            wmaids = self.mgr.file_write(fname, self.data)
+            self.assertEqual(len(wmaids), 1)
+            data = self.mgr.file_read(fname)
+            self.assertEqual(data[0], self.data)
 #
 # main
 #

--- a/test/python/WMArchive_t/FileIO_t.py
+++ b/test/python/WMArchive_t/FileIO_t.py
@@ -43,14 +43,6 @@ class FileStorageTest(unittest.TestCase):
         data = self.mgr.read(wmaids[0])
         self.assertEqual(data[0], self.bare_data)
 
-    def test_write_bulk(self):
-        "Test write functionality"
-        bdata = [self.data, self.data]
-        bare_data = [self.bare_data, self.bare_data]
-        wmaids = self.mgr.write_bulk(bdata)
-        self.assertEqual(len(wmaids), 1)
-        data = self.mgr.read(wmaids[0])
-        self.assertEqual(data, bare_data)
 #
 # main
 #

--- a/test/python/WMArchive_t/MongoIO_t.py
+++ b/test/python/WMArchive_t/MongoIO_t.py
@@ -52,31 +52,6 @@ class MongoStorageTest(unittest.TestCase):
                 del record[key]
             self.assertEqual(record, self.bare_data)
 
-    def test_write_bulk(self):
-        "Test write functionality"
-        data1 = dict(self.bare_data)
-        data1['idx'] = 1
-        data2 = dict(self.bare_data)
-        data2['idx'] = 2
-        bare_data = [data1, data2]
-
-        bdata1 = dict(data1)
-        bdata1['wmaid'] = wmaHash(data1)
-        bdata1['stype'] = 'mongodb'
-        bdata2 = dict(data2)
-        bdata2['wmaid'] = wmaHash(data2)
-        bdata2['stype'] = 'mongodb'
-        bdata = [bdata1, bdata2]
-
-        wmaids = self.mgr.write_bulk(bdata)
-        self.assertEqual(len(wmaids), 2) # in Mongo bulk still writes separate docs
-        data = self.mgr.read()
-        out = []
-        for rec in data:
-            for key in ['wmaid', 'stype']:
-                del rec[key]
-            out.append(rec)
-        self.assertEqual(out, bare_data)
 #
 # main
 #

--- a/test/python/WMArchive_t/Tools_t.py
+++ b/test/python/WMArchive_t/Tools_t.py
@@ -22,21 +22,16 @@ from avro.io import DatumReader, DatumWriter
 
 # WMArchive modules
 from WMArchive.Tools.json2avsc import genSchema
-from WMArchive.Utils.Utils import bulk_data, bulk_avsc
 
-def json2avro2json(data, bulk=False):
+def json2avro2json(data):
     """
     Function which reads json file, generates avro screma, convert json to
     avro and convert it back using the schema. All operations are done in
     memory (via io.BytesIO)
     """
     # parse schema into schema object
-    if  bulk:
-        arec = genSchema(data['bulk'][0])
-        schema = avro.schema.parse(json.dumps(bulk_avsc(arec)))
-    else:
-        arec = genSchema(data)
-        schema = avro.schema.parse(json.dumps(arec))
+    arec = genSchema(data)
+    schema = avro.schema.parse(json.dumps(arec))
 
     # setup avro writer with given schema
     writer = avro.io.DatumWriter(schema)
@@ -75,14 +70,6 @@ class WMBaseTest(unittest.TestCase):
                 json_data = json2avro2json(data)
                 self.assertEqual(json_data, data)
 
-    def test_genSchema_bulk(self):
-        "Test genSchema function with bulk data"
-        data = {"int":1, "float":1.2, "list":[1,2,3],
-                "dict":{"dname": "foo", "dval":1},
-                "listdict":[{"lname":"foo"}], "str":"string"}
-        bdata = bulk_data(data)
-        json_data = json2avro2json(bdata, bulk=True)
-        self.assertEqual(json_data, bdata)
 #
 # main
 #

--- a/test/python/WMArchive_t/Utils_t.py
+++ b/test/python/WMArchive_t/Utils_t.py
@@ -14,7 +14,7 @@ import os
 import unittest
 
 # WMArchive modules
-from WMArchive.Utils.Utils import wmaHash, dateformat
+from WMArchive.Utils.Utils import wmaHash, dateformat, file_name
 
 class WMBaseTest(unittest.TestCase):
     def test_wmaHash(self):
@@ -38,6 +38,19 @@ class WMBaseTest(unittest.TestCase):
         self.assertRaises(Exception, dateformat, wrong)
         wrong = '2012'
         self.assertRaises(Exception, dateformat, wrong)
+
+    def test_file_name(self):
+        "Test file_name function"
+        uri = 'test'
+        wmaid = 123
+        for compress in ['', 'bz2', 'gz']:
+            fname = file_name(uri, wmaid, compress)
+            if  compress:
+                tname = '%s/%s.avro.%s' % (uri, wmaid, compress)
+            else:
+                tname = '%s/%s.avro' % (uri, wmaid)
+            self.assertEqual(fname, tname)
+        self.assertRaises(Exception, file_name, (uri, wmaid, 'gzip'))
 #
 # main
 #


### PR DESCRIPTION
use append mode while writing avro docs into bz2 stream; unify compression mechanism (supported formats either .gz or .bz2)
