### PR TITLE
try/excepting small problem in json2avro, needs fix in AvroStorage?

### DIFF
--- a/src/python/WMArchive/Tools/json2avro.py
+++ b/src/python/WMArchive/Tools/json2avro.py
@@ -40,8 +40,11 @@ def migrate(fin, fout, avsc):
 
     # store data to Avro
     res = astg.file_write(fout, data)
-    wmaid = res.next() # The file_write API is generator and we need to advance
-    print("Wrote %s, wmaid=%s" % (fout, wmaid))
+    try:
+        wmaid = res.next() # This should be fixed in AvroStorage
+        print("Wrote %s, wmaid=%s" % (fout, wmaid))
+    except AttributeError, e:
+        print("Wrote %s, wmaid=%s" % (fout, res[0]))
 
 def main():
     "Main function"


### PR DESCRIPTION
This cannot work:
https://github.com/dmwm/WMArchive/blob/master/src/python/WMArchive/Tools/json2avro.py#L43

as return value of file_write is a list:
https://github.com/dmwm/WMArchive/blob/master/src/python/WMArchive/Storage/AvroIO.py#L80

Not sure how the file_write API was supposed to look like. For now I just try/excepted the offending code and used res[0] instead of res.next()
