### PR TITLE
pyspark: Yarn master and aggregation example 

### DIFF
--- a/bin/myspark
+++ b/bin/myspark
@@ -18,23 +18,29 @@ avrojar=/usr/lib/avro/avro-mapred.jar
 sparkexjar=/usr/lib/spark/examples/lib/spark-examples-1.3.0-cdh5.4.2-hadoop2.6.0-cdh5.4.2.jar
 
 if [ "$1" == "-h" ] || [ "$1" == "--help" ] || [ "$1" == "-help" ]; then
-	# run help
+    # run help
     python $wmaroot/Tools/myspark.py --help
-else
-    # here we use yarn master to submit our job to a cluster
-    # other options would be to use local master to run on a single node
+elif [ "$1" == "--yarn" ] || [ "$1" == "-yarn" ]; then
+    # to tune up these numbers:
+    #  - executor-memory not more than 5G
+    #  - num-executor can be increased (suggested not more than 10)
+    #  - cores = 2/4/8
     spark-submit --driver-class-path $avrojar:$sparkexjar \
-        --master=local \
-#        --master=yarn \
+        --executor-memory 4G \
+        --num-executors 4 \
+        --master yarn-client \
+        --executor-cores 4 \
+        $wmaroot/Tools/myspark.py ${1+"$@"}    
+else
+    # submit spark job with our file, please note
+    # that user may increase memory options if necessary
+    # the executor and driver memory options can be given in human readable form
+    # while spark yarn option should use memoryOverhead as KB value.
+
+    # Modify with local[*] to use all the available cores in the node
+    #   optionally increase driver memory with --driver-memory 2G (default 1G)
+    spark-submit --driver-class-path $avrojar:$sparkexjar \
+        --executor-memory $((`nproc`/4))G \
+        --master local[$((`nproc`/4))] \
         $wmaroot/Tools/myspark.py ${1+"$@"}
-# Original example
-# submit spark job with our file, please note
-# that user may increase memory options if necessary
-# the executor and driver memory options can be given in human readable form
-# while spark yarn option should use memoryOverhead as KB value
-#    spark-submit --driver-class-path $avrojar:$sparkexjar \
-#        --executor-memory 4G \
-#        --driver-memory 4G \
-#        --conf spark.yarn.executor.memoryOverhead=4096 \
-#        $wmaroot/Tools/myspark.py ${1+"$@"}
 fi

--- a/src/python/WMArchive/PySpark/PySparkJSON2ParquetExample.py
+++ b/src/python/WMArchive/PySpark/PySparkJSON2ParquetExample.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""
+File       : PySparkJSON2ParquetExample.py
+Author     : Luca Menichetti <luca.menichetti AT cern dot ch>
+Description: How to convert a set of JSONs into Parquet
+"""
+
+from pyspark import SparkContext, SparkConf
+from pyspark.sql import SQLContext
+
+import json
+
+conf = SparkConf().setAppName("pyspark fwjr JSONs 2 parquet")
+sc = SparkContext(conf=conf)
+sqlc = SQLContext(sc)
+
+
+def jsons2Parquet(list_of_docs, output_folder_name):
+    """
+    This function expects a list of JSON documents and output folder name.
+    It should process each document, convert to parquet data format and
+    write it out to given output folder
+    """
+    jsonDocsDF = sqlc.jsonRDD(sc.parallelize([json.dumps(j) for j in list_of_docs]))
+    jsonDocsDF.saveAsParquetFile(output_folder_name)

--- a/src/python/WMArchive/PySpark/RecordReader.py
+++ b/src/python/WMArchive/PySpark/RecordReader.py
@@ -33,7 +33,7 @@ class MapReduce(object):
             rsize += storage['readTotalMB']
             wsize += storage['writeTotalMB']
             count += 1
-        summary = {'cpu':tot_cpu, 'time':tot_time, 'rsize':rsize, 'wsize':wsize, 'docs':count}
+        summary = [('cpu',tot_cpu), ('time',tot_time), ('rsize',rsize), ('wsize',wsize), ('docs',count)]
         return summary
 
     def reducer(self, records, init=0):

--- a/src/python/WMArchive/Tools/myspark.py
+++ b/src/python/WMArchive/Tools/myspark.py
@@ -163,12 +163,13 @@ def run(schema_file, data_path, script=None, spec_file=None, verbose=None):
         mro = obj.MapReduce(spec)
         # example of collecting records from mapper and
         # passing all of them to reducer function
-        records = avro_rdd.map(mro.mapper).collect()
-        out = mro.reducer(records)
+        # records = avro_rdd.map(mro.mapper).collect()
+        # out = mro.reducer(records)
 
         # the map(f).reduce(f) example but it does not collect
         # intermediate records
         # out = avro_rdd.map(obj.mapper).reduce(obj.reducer).collect()
+        out = avro_rdd.flatMap(obj.mapper).reduceByKey(lambda a, b: a + b).collect()
     else:
         records = avro_rdd.map(basic_mapper).collect()
         out = basic_reducer(records)


### PR DESCRIPTION
#### Adding yarn master parameter:

The spark-submit command take two different kinds of parameters depending if there is "yarn" or "local" specified as --master, hence I would suggest to separate the two cases.

Since I guess the local mode will be running in the 32cores node, 1/4 of the resources are sufficient and won't bother other users a lot (this was my assumption, another option can be to parametrize everything).
#### Refactoring RecordReader example:

To use the [reduce()](https://spark.apache.org/docs/1.3.0/api/python/pyspark.html#pyspark.RDD.reduce) function isn't correct in this case because it is an action (nothing in common with the classic Hadoop reducer). I see that the Python documentation is terrible, I suggest to have a look at the [programming guide](http://spark.apache.org/docs/1.3.0/programming-guide.html#actions) and the [Scala doc](http://spark.apache.org/docs/1.3.0/api/scala/index.html#org.apache.spark.rdd.RDD), just for the signatures written in functional programming style. E.g:  reduce(f: (T, T) ⇒ T): T.

The RecordReader therefore needs only the mapper() method, the reduce() will be replaced by "lambda a, b: a + b".

n.b. I didn't manage to test everything because I'm missing something when I'm trying to set up the environment.
#### Json 2 Parquet example:

The function takes a list of JSON documents (list of dicts) and write a parquet files the output folders. It can be improved giving the number of repartitions (#of chunks for the parquet files). By default writes in HDFS, it needs different marker ("file://") to write the result locally.
