### PR TITLE
myspark updated spark submission (with yarn)

### DIFF
--- a/bin/myspark
+++ b/bin/myspark
@@ -18,14 +18,30 @@ avrojar=/usr/lib/avro/avro-mapred.jar
 sparkexjar=/usr/lib/spark/examples/lib/spark-examples-1.3.0-cdh5.4.2-hadoop2.6.0-cdh5.4.2.jar
 
 if [ "$1" == "-h" ] || [ "$1" == "--help" ] || [ "$1" == "-help" ]; then
-	# run help
+    # run help
     python $wmaroot/Tools/myspark.py --help
-else
-    # here we use yarn master to submit our job to a cluster
-    # other options would be to use local master to run on a single node
+elif [ "$1" == "--yarn" ] || [ "$1" == "-yarn" ]; then
+    # to tune up these numbers:
+    #  - executor-memory not more than 5G
+    #  - num-executor can be increased (suggested not more than 10)
+    #  - cores = 2/4/8
     spark-submit --driver-class-path $avrojar:$sparkexjar \
-        --master=local \
-#        --master=yarn \
+        --executor-memory 4G \
+        --num-executors 4 \
+        --master yarn-client \
+        --executor-cores 4 \
+        $wmaroot/Tools/myspark.py ${1+"$@"} 
+else
+    # submit spark job with our file, please note
+    # that user may increase memory options if necessary
+    # the executor and driver memory options can be given in human readable form
+    # while spark yarn option should use memoryOverhead as KB value.
+
+    # Modify with local[*] to use all the available cores in the node
+    #   optionally increase driver memory with --driver-memory 2G (default 1G)
+    spark-submit --driver-class-path $avrojar:$sparkexjar \
+        --executor-memory $((`nproc`/4))G \
+        --master local[$((`nproc`/4))] \
         $wmaroot/Tools/myspark.py ${1+"$@"}
 # Original example
 # submit spark job with our file, please note


### PR DESCRIPTION
The spark-submit command take two different kinds of parameters depending if there is "yarn" or "local" specified as --master, hence I would suggest to separate the two cases.

Since I guess the local mode will be running in the 32cores node, 1/4 of the resources are sufficient and won't bother other users a lot (this was my assumption, another option can be to parametrize everything).
