### PR TITLE
ParquetIO, new storage element

### DIFF
--- a/src/python/WMArchive/Storage/ParquetIO.py
+++ b/src/python/WMArchive/Storage/ParquetIO.py
@@ -13,12 +13,16 @@ class ParquetIO(object):
         self.sqlc = sparkSQLContext
         self.sc = sparkContext
 
-    def file_write(self, fname, data):
+    def file_write(self, fname, data, repartitionNumber=None):
         """
         fname: output folder name, usually a HDFS path
         data: an array of JSONs
+        repartitionNumer: [optional] the number of partitions used to write the output file
         """
         if not self.sqlc or not self.sc:
             raise Exception("Both Spark Context and SQLContext have to be available")
         jsonDocsDF = self.sqlc.jsonRDD(self.sc.parallelize([json.dumps(j) for j in data]))
-        jsonDocsDF.saveAsParquetFile(fname)
+        if repartitionNumber:
+            jsonDocsDF.repartition(repartitionNumber).saveAsParquetFile(fname)
+        else:
+            jsonDocsDF.saveAsParquetFile(fname)

--- a/src/python/WMArchive/Storage/ParquetIO.py
+++ b/src/python/WMArchive/Storage/ParquetIO.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""
+File       : ParquetIO.py
+Author     : Luca Menichetti <luca.menichetti AT cern dot ch>
+Description: Converts a set of JSONs into Parquet,
+             Spark SQLContext is needed (or HiveContext)
+"""
+
+import json
+
+class ParquetIO(object):
+    def __init__(self, sparkContext, sparkSQLContext):
+        self.sqlc = sparkSQLContext
+        self.sc = sparkContext
+
+    def file_write(self, fname, data):
+        """
+        fname: output folder name, usually a HDFS path
+        data: an array of JSONs
+        """
+        if not self.sqlc or not self.sc:
+            raise Exception("Both Spark Context and SQLContext have to be available")
+        jsonDocsDF = self.sqlc.jsonRDD(self.sc.parallelize([json.dumps(j) for j in data]))
+        jsonDocsDF.saveAsParquetFile(fname)


### PR DESCRIPTION
Storage object to convert list of JSONs in Parquet format. ParquetIO.file_write() takes a list of JSON documents (list of dicts) and write a parquet files into the output folder. Optionally takes a repartition number as parameter.
