### PR TITLE
Enabling Yarn mode

### DIFF
--- a/bin/myspark
+++ b/bin/myspark
@@ -26,7 +26,7 @@ elif [ "$1" == "--yarn" ] || [ "$1" == "-yarn" ]; then
     #  - num-executor can be increased (suggested not more than 10)
     #  - cores = 2/4/8
     PYSPARK_PYTHON='/afs/cern.ch/user/l/lmeniche/public/python27' \
-        spark-submit --driver-class-path $avrojar:$sparkexjar \
+        spark-submit --jars $avrojar,$sparkexjar \
             --executor-memory 4G \
             --num-executors 4 \
             --master yarn-client \
@@ -40,7 +40,7 @@ else
 
     # Modify with local[*] to use all the available cores in the node
     #   optionally increase driver memory with --driver-memory 2G (default 1G)
-    spark-submit --driver-class-path $avrojar:$sparkexjar \
+    spark-submit --jars $avrojar,$sparkexjar \
         --executor-memory $((`nproc`/4))G \
         --master local[$((`nproc`/4))] \
         $wmaroot/Tools/myspark.py ${1+"$@"}

--- a/bin/myspark
+++ b/bin/myspark
@@ -25,12 +25,13 @@ elif [ "$1" == "--yarn" ] || [ "$1" == "-yarn" ]; then
     #  - executor-memory not more than 5G
     #  - num-executor can be increased (suggested not more than 10)
     #  - cores = 2/4/8
-    spark-submit --driver-class-path $avrojar:$sparkexjar \
-        --executor-memory 4G \
-        --num-executors 4 \
-        --master yarn-client \
-        --executor-cores 4 \
-        $wmaroot/Tools/myspark.py ${1+"$@"} 
+    PYSPARK_PYTHON='/afs/cern.ch/user/l/lmeniche/public/python27' \
+        spark-submit --driver-class-path $avrojar:$sparkexjar \
+            --executor-memory 4G \
+            --num-executors 4 \
+            --master yarn-client \
+            --executor-cores 4 \
+            $wmaroot/Tools/myspark.py ${1+"$@"} 
 else
     # submit spark job with our file, please note
     # that user may increase memory options if necessary

--- a/src/python/WMArchive/Tools/myspark.py
+++ b/src/python/WMArchive/Tools/myspark.py
@@ -42,6 +42,8 @@ class OptionParser():
             dest="spec", default="", help=msg)
         self.parser.add_argument("--verbose", action="store_true",
             dest="verbose", default=False, help="verbose output")
+        self.parser.add_argument("--yarn", action="store_true",
+            dest="yarn", default=False, help="true if yarn mode is enabled")
 
 def basic_mapper(records):
     """
@@ -121,6 +123,8 @@ def run(schema_file, data_path, script=None, spec_file=None, verbose=None):
     logger = SparkLogger(ctx)
     if  not verbose:
         logger.set_level('ERROR')
+    if yarn:
+        logger.info("YARN client mode enabled")
 
     # load FWJR schema
     rdd = ctx.textFile(schema_file, 1).collect()

--- a/src/python/WMArchive/Tools/myspark.py
+++ b/src/python/WMArchive/Tools/myspark.py
@@ -108,7 +108,7 @@ def import_(filename):
     ifile, filename, data = imp.find_module(name, [path])
     return imp.load_module(name, ifile, filename, data)
 
-def run(schema_file, data_path, script=None, spec_file=None, verbose=None):
+def run(schema_file, data_path, script=None, spec_file=None, verbose=None, yarn=None):
     """
     Main function to run pyspark job. It requires a schema file, an HDFS directory
     with data and optional script with mapper/reducer functions.
@@ -119,7 +119,7 @@ def run(schema_file, data_path, script=None, spec_file=None, verbose=None):
 
     # define spark context, it's main object which allow
     # to communicate with spark
-    ctx = SparkContext(appName="AvroKeyInputFormat")
+    ctx = SparkContext(appName="AvroKeyInputFormat", pyFiles=[script])
     logger = SparkLogger(ctx)
     if  not verbose:
         logger.set_level('ERROR')
@@ -185,7 +185,7 @@ def main():
     "Main function"
     optmgr  = OptionParser()
     opts = optmgr.parser.parse_args()
-    results = run(opts.schema, opts.hdir, opts.script, opts.spec, opts.verbose)
+    results = run(opts.schema, opts.hdir, opts.script, opts.spec, opts.verbose, opts.yarn)
     print(results)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a temporary solution until we will enable python 2.7 on all nodes in the cluster. For the moment all pyspark jobs in cluster mode will have to be launched using this script as default Python: /afs/cern.ch/user/l/lmeniche/public/python27

Alas, vocms013 is already using that version, therefore we have to exclude it from the script. This done inside the script.

Another important missing step is iptables. Currently running with the --yarn parameter, the job will fail because of executors that are not able to connect to vocms013. E.g.

```
16/03/15 18:22:33 ERROR yarn.ApplicationMaster: Failed to connect to driver at vocms013.cern.ch:50309, retrying ...
```

When a driver is running outside the cluster, it needs to open random port with all the executors inside the cluster in order to orchestrate the computation. There are basically two solutions: the first one is to use puppet to insert iptables rules accepting everything from each node of the cluster; the second one is to switch off iptables.
