### PR TITLE
Updated with Spark 1.3.0 syntax and moved compression command

### DIFF
--- a/src/python/WMArchive/Storage/AvroSnappyIO.py
+++ b/src/python/WMArchive/Storage/AvroSnappyIO.py
@@ -22,8 +22,8 @@ class AvroSnappyIO(object):
         if not self.sqlc or not self.sc:
             raise Exception("Both Spark Context and SQLContext must be available")
         jsonDocsDF = self.sqlc.jsonRDD(self.sc.parallelize([json.dumps(j) for j in data]))
+        sqlContext.setConf("spark.sql.avro.compression.codec", "snappy")
         if repartitionNumber:
-            sqlContext.setConf("spark.sql.avro.compression.codec", "snappy")
-            jsonDocsDF.repartition(repartitionNumber).write.mode(write_mode).format("com.databricks.spark.avro").save(fname)
+            jsonDocsDF.repartition(repartitionNumber).save(fname, "com.databricks.spark.avro", mode=write_mode)
         else:
-            jsonDocsDF.write.mode(write_mode).format("com.databricks.spark.avro").save(fname)
+            jsonDocsDF.save(fname, "com.databricks.spark.avro", mode=write_mode)


### PR DESCRIPTION
Corrected with Spark 1.3.0 syntax

and option must be:

```
--packages com.databricks:spark-avro_2.10:1.0.0
```
