### PR TITLE
add Campaign and PrepID in top level

### DIFF
--- a/src/python/WMArchive/Schemas/FWJRProduction.py
+++ b/src/python/WMArchive/Schemas/FWJRProduction.py
@@ -20,6 +20,10 @@ fwjr = \
               ],
  'PFNArrayRef': ['inputPFNs', 'outputPFNs', 'pfn'],  # list of keys whose value is referencing fileArray index
  
+ 'Campaign': 'TestCampaign',
+ 
+ 'PrepID': 'TestPrepID',
+ 
  'steps': [{'name': 'cmsRun1',
              #'analysis': {}, 
              #'cleanup': {},


### PR DESCRIPTION
Agent is not patched yet but schema can be changed. All queries using this new parameters can be added in next deployment.
@vkuznet, please review.