### PR TITLE
Add eventsPerLumi to schema

### DIFF
--- a/src/python/WMArchive/Schemas/FWJRProduction.py
+++ b/src/python/WMArchive/Schemas/FWJRProduction.py
@@ -72,6 +72,7 @@ fwjr = \
                          'processingStr': 'RECOCOSD_TaskChain_Data_pile_up_test',
                          'processingVer': 1,
                          'runs': [{'lumis': [164, 165],
+                                   'eventsPerLumi': [100, 150],
                                    'runNumber': 160960}],
                          'size': 647376,
                          'validStatus': 'PRODUCTION',


### PR DESCRIPTION
This is the schema change that allows us to insert events per lumi for output files. I'm a bit unsure if this can be added before such data starts appearing from the agent. What happens if this key/value pair is not present?

